### PR TITLE
Format logging

### DIFF
--- a/haku-app/src/main/java/fi/vm/sade/haku/provider/ResourceNotFoundExceptionMapper.java
+++ b/haku-app/src/main/java/fi/vm/sade/haku/provider/ResourceNotFoundExceptionMapper.java
@@ -45,7 +45,7 @@ public class ResourceNotFoundExceptionMapper implements ExceptionMapper<Resource
     public Response toResponse(ResourceNotFoundException exception) {
         String timestamp = new SimpleDateFormat("dd.MM.yyyy HH:mm:ss").format(new Date());
         String uuid = UUID.randomUUID().toString();
-        LOGGER.error("Error: " + uuid, exception);
+        LOGGER.warn("Error (" + uuid + "): " + exception.getMessage());
         Map<String, String> model = ImmutableMap.of(
                 MODEL_STACK_TRACE, exception.toString(),
                 MODEL_MESSAGE, exception.getMessage(),


### PR DESCRIPTION
Do not print stacktrace from ResourceNotFoundException which is raised e.g. when
user session times out or user tries to access resource that returns status code
404.
