### PR TITLE
Fix eligibility notifications

### DIFF
--- a/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/hakemus/domain/BaseEducations.java
+++ b/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/hakemus/domain/BaseEducations.java
@@ -367,4 +367,31 @@ public class BaseEducations {
             }
         };
     }
+
+    public static class HarkinnanvarainenTaiErivapaus {
+        private static final String fieldPrefix = "pohjakoulutus_muu";
+        public final String vuosi;
+        public final String kuvaus;
+
+        private HarkinnanvarainenTaiErivapaus(String vuosi, String kuvaus) {
+            this.vuosi = vuosi;
+            this.kuvaus = kuvaus;
+        }
+
+        public static final Function<MergedAnswers, ImmutableSet<HarkinnanvarainenTaiErivapaus>> of = new Function<MergedAnswers, ImmutableSet<HarkinnanvarainenTaiErivapaus>>() {
+            @Override
+            public ImmutableSet<HarkinnanvarainenTaiErivapaus> apply(MergedAnswers answers) {
+                String valinta = answers.get(fieldPrefix);
+
+                if ("true".equals(valinta)) {
+                    String vuosi = answers.get(fieldPrefix + "_vuosi");
+                    String kuvaus = answers.get(fieldPrefix + "_kuvaus");
+                    variablesNotNull(vuosi, kuvaus);
+                    return ImmutableSet.of(new HarkinnanvarainenTaiErivapaus(vuosi, kuvaus));
+                } else {
+                    return ImmutableSet.of();
+                }
+            }
+        };
+    }
 }

--- a/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/hakemus/service/EducationRequirementsUtil.java
+++ b/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/hakemus/service/EducationRequirementsUtil.java
@@ -199,6 +199,22 @@ public class EducationRequirementsUtil {
         };
     }
 
+    private final static Function<Types.MergedAnswers, ImmutableSet<Eligibility>> harkinnanvaraisuusTaiMuuErivapaus = wrapSetWhere(
+        BaseEducations.HarkinnanvarainenTaiErivapaus.of,
+        new Predicate<BaseEducations.HarkinnanvarainenTaiErivapaus>() {
+            @Override
+            public boolean apply(BaseEducations.HarkinnanvarainenTaiErivapaus input) {
+                return true;
+            }
+        },
+        new Function<BaseEducations.HarkinnanvarainenTaiErivapaus, Eligibility>() {
+            @Override
+            public Eligibility apply(BaseEducations.HarkinnanvarainenTaiErivapaus erivapaus) {
+                return Eligibility.suomalainen(erivapaus.kuvaus);
+            }
+        });
+
+
     private final static Function<Types.MergedAnswers, ImmutableSet<Eligibility>> ignore = new Function<Types.MergedAnswers, ImmutableSet<Eligibility>>() {
         @Override
         public ImmutableSet<Eligibility> apply(Types.MergedAnswers answers) {
@@ -230,7 +246,7 @@ public class EducationRequirementsUtil {
     /* Determine which ApplicationSystem fields fullfills the given base education requirements */
     // Pohjakoulutuskoodit: https://testi.virkailija.opintopolku.fi/koodisto-service/rest/codeelement/codes/pohjakoulutusvaatimuskorkeakoulut/1
     public static final ImmutableMap<String, Function<Types.MergedAnswers, ImmutableSet<Eligibility>>> kkBaseEducationRequirements = ImmutableMap.<String, Function<Types.MergedAnswers, ImmutableSet<Eligibility>>>builder()
-            // Ylempi korkeakoulututkinto
+                    // Ylempi korkeakoulututkinto
             .put("pohjakoulutusvaatimuskorkeakoulut_103", multipleChoiceKkEquals("4"))
                     // Ylempi ammattikorkeakoulututkinto
             .put("pohjakoulutusvaatimuskorkeakoulut_119", multipleChoiceKkEquals("3"))
@@ -262,7 +278,7 @@ public class EducationRequirementsUtil {
                     // TODO: tällä ei ole _nimike-kenttää
             .put("pohjakoulutusvaatimuskorkeakoulut_110", europeanBaccalaureateTutkinto)
                     // Harkinnanvaraisuus tai erivapaus
-            .put("pohjakoulutusvaatimuskorkeakoulut_106", ignore)
+            .put("pohjakoulutusvaatimuskorkeakoulut_106", harkinnanvaraisuusTaiMuuErivapaus)
                     // International Baccalaureate -tutkinto
             .put("pohjakoulutusvaatimuskorkeakoulut_112", internationalBaccalaureateTutkinto)
                     // Opisto- tai ammatillisen korkea-asteen tutkinto


### PR DESCRIPTION
No eligibility warning when selected base education is "muu
korkeakoulukelpoisuus" and the application option has enabled
"harkinnanvaraisuus" as required base education.
