### PR TITLE
Show edit form (but don't persist changes) when valinnat is down

### DIFF
--- a/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/hakemus/service/ApplicationService.java
+++ b/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/hakemus/service/ApplicationService.java
@@ -74,6 +74,8 @@ public interface ApplicationService {
      */
     void saveApplicationAdditionalInfo(final String oid, final Map<String, String> additionalInfo);
 
+    void update(final Application application, boolean postProcess);
+
     void update(final Application queryApplication, final Application application);
 
     void update(Application queryApplication, Application application,

--- a/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/hakemus/service/impl/ApplicationServiceImpl.java
+++ b/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/hakemus/service/impl/ApplicationServiceImpl.java
@@ -742,6 +742,12 @@ public class ApplicationServiceImpl implements ApplicationService {
     }
 
     @Override
+    public void update(Application application, boolean postProcess) {
+        Application queryApplication = new Application(application.getOid(), application.getVersion());
+        this.update(queryApplication, application, postProcess);
+    }
+
+    @Override
     public void update(final Application queryApplication, final Application application,
                        final boolean postProcess) {
         if (postProcess) {

--- a/hakemus-api/src/main/resources/messages_en.properties
+++ b/hakemus-api/src/main/resources/messages_en.properties
@@ -98,6 +98,7 @@ virkailija.hakemus.lahtokoulu               = [en] L\u00E4ht\u00F6koulu ja -luok
 virkailija.hakemus.nimi                     = [en] Nimi
 virkailija.hakemus.omanmuokkauskielletty    = [en] Oman hakemuksen muokkaus on estetty
 virkailija.hakemus.valintaservicefail       = [en] Hakemuksen tietojen haku valinnoista ep\u00E4onnistui
+virkailija.hakemus.valinnatfail.block.save  = [en] Hakemusta ei voida tallentaa, koska hakemuksen tietojen haku valinnoista ep\u00E4onnistui. Yrit\u00E4 my\u00F6hemmin uudelleen.
 virkailija.hakemus.oppijanumero             = [en] Oppijanumero
 virkailija.hakemus.paivita                  = [en] P\u00E4ivit\u00E4
 virkailija.hakemus.passivoi.hakemus         = [en] Passivoi hakemus

--- a/hakemus-api/src/main/resources/messages_fi.properties
+++ b/hakemus-api/src/main/resources/messages_fi.properties
@@ -98,6 +98,7 @@ virkailija.hakemus.lahtokoulu               = L\u00E4ht\u00F6koulu ja -luokka
 virkailija.hakemus.nimi                     = Nimi
 virkailija.hakemus.omanmuokkauskielletty    = Oman hakemuksen muokkaus on estetty
 virkailija.hakemus.valintaservicefail       = Hakemuksen tietojen haku valinnoista ep\u00E4onnistui
+virkailija.hakemus.valinnatfail.block.save  = Hakemusta ei voida tallentaa, koska hakemuksen tietojen haku valinnoista ep\u00E4onnistui. Yrit\u00E4 my\u00F6hemmin uudelleen.
 virkailija.hakemus.oppijanumero             = Oppijanumero
 virkailija.hakemus.paivita                  = P\u00E4ivit\u00E4
 virkailija.hakemus.passivoi.hakemus         = Passivoi hakemus

--- a/hakemus-api/src/main/resources/messages_sv.properties
+++ b/hakemus-api/src/main/resources/messages_sv.properties
@@ -95,6 +95,7 @@ virkailija.hakemus.lahtokoulu               = Nuvarande skola och klass
 virkailija.hakemus.nimi                     = Namn
 virkailija.hakemus.omanmuokkauskielletty    = Behandling av egen ans\u00F6kning \u00E4r f\u00F6rhindrat
 virkailija.hakemus.valintaservicefail       = Att s\u00F6ka data om ans\u00F6kan fr\u00E5n antagningen misslyckades
+virkailija.hakemus.valinnatfail.block.save  = Ans\u00F6kan kunde inte sparas f\u00F6r att det gick inte att s\u00F6ka data om ans\u00F6kan fr\u00E5n antagningen. F\u00F6rs\u00F6k p\u00E5 nytt senare.
 virkailija.hakemus.oppijanumero             = Studerandenummer
 virkailija.hakemus.paivita                  = P\u00E4ivit\u00E4
 virkailija.hakemus.passivoi.hakemus         = Passivera ans\u00F6kan


### PR DESCRIPTION
Previously, if valinnat was down and the user tried to update
phase answers, a blank form with
two save buttons was shown. This could cause data to disappear,
because if the user clicked on the save button (and meanwhile valinnat
would go up again) the save was successful and data disappeared.
