### PR TITLE
BUG-1107 : Longer timeout for koostepalvelu call in jälkikäsittely

### DIFF
--- a/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/hakemus/service/ApplicationService.java
+++ b/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/hakemus/service/ApplicationService.java
@@ -26,6 +26,7 @@ import fi.vm.sade.haku.oppija.lomake.domain.ApplicationState;
 import fi.vm.sade.haku.virkailija.valinta.ValintaServiceCallFailedException;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +38,7 @@ public interface ApplicationService {
 
     Map<String, String> ensureApplicationOptionGroupData(Map<String, String> answers, String lang);
 
-    Application postProcessApplicationAnswers(Application application) throws ValintaServiceCallFailedException;
+    Application postProcessApplicationAnswers(Application application, Duration postProcessorValintaTimeout) throws ValintaServiceCallFailedException;
 
     Application getApplication(final Application queryApplication);
 

--- a/hakemus-api/src/main/java/fi/vm/sade/haku/virkailija/valinta/ValintaService.java
+++ b/hakemus-api/src/main/java/fi/vm/sade/haku/virkailija/valinta/ValintaService.java
@@ -4,7 +4,9 @@ import fi.vm.sade.haku.oppija.hakemus.domain.Application;
 import fi.vm.sade.haku.virkailija.valinta.dto.HakemusDTO;
 import fi.vm.sade.haku.virkailija.valinta.dto.HakijaDTO;
 
+import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 
 public interface ValintaService {
 
@@ -12,5 +14,5 @@ public interface ValintaService {
 
     HakijaDTO getHakija(String asOid, String application);
 
-    Map<String, String> fetchValintaData(Application application) throws ValintaServiceCallFailedException;
+    Map<String, String> fetchValintaData(Application application, Optional<Duration> valintaTimeout) throws ValintaServiceCallFailedException;
 }

--- a/hakemus-api/src/main/java/fi/vm/sade/haku/virkailija/valinta/impl/ValintaServiceMockImpl.java
+++ b/hakemus-api/src/main/java/fi/vm/sade/haku/virkailija/valinta/impl/ValintaServiceMockImpl.java
@@ -2,7 +2,6 @@ package fi.vm.sade.haku.virkailija.valinta.impl;
 
 import com.google.gson.*;
 import fi.vm.sade.haku.oppija.hakemus.domain.Application;
-import fi.vm.sade.haku.oppija.lomake.exception.IllegalStateException;
 import fi.vm.sade.haku.virkailija.valinta.ValintaService;
 import fi.vm.sade.haku.virkailija.valinta.ValintaServiceCallFailedException;
 import fi.vm.sade.haku.virkailija.valinta.dto.HakemusDTO;
@@ -11,9 +10,11 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 import java.lang.reflect.Type;
+import java.time.Duration;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @Profile(value = {"dev", "it"})
@@ -847,7 +848,7 @@ public class ValintaServiceMockImpl implements ValintaService {
     }
 
     @Override
-    public Map<String, String> fetchValintaData(Application application) throws ValintaServiceCallFailedException{
+    public Map<String, String> fetchValintaData(Application application, Optional<Duration> valintaTimeout) throws ValintaServiceCallFailedException{
         Map<String, String> result = new HashMap<>();
         for(Map<String, String> r : application.getAnswers().values()) {
             result.putAll(r);

--- a/haku-app/src/test/java/fi/vm/sade/haku/oppija/hakemus/service/impl/ApplicationServiceImplTest.java
+++ b/haku-app/src/test/java/fi/vm/sade/haku/oppija/hakemus/service/impl/ApplicationServiceImplTest.java
@@ -56,6 +56,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
@@ -108,6 +109,7 @@ public class ApplicationServiceImplTest {
     private ApplicationServiceImpl service;
     private ElementTreeValidator elementTreeValidator;
     private I18nBundleService i18nBundleService;
+    private Optional<Duration> valintaTimeout = Optional.empty();
 
     @Before
     public void setUp() throws Exception {
@@ -392,7 +394,7 @@ public class ApplicationServiceImplTest {
         Map<String, String> valintaEducationAnswers = new HashMap<>(originalEducationAnswers);
         valintaEducationAnswers.put(OppijaConstants.ELEMENT_ID_BASE_EDUCATION, OppijaConstants.OSITTAIN_YKSILOLLISTETTY);
         ValintaService valintaService = mock(ValintaService.class);
-        when(valintaService.fetchValintaData(Mockito.<Application>any())).thenReturn(valintaEducationAnswers);
+        when(valintaService.fetchValintaData(Mockito.<Application>any(), Mockito.same(valintaTimeout))).thenReturn(valintaEducationAnswers);
 
         when(applicationSystemService.getApplicationSystem(eq("myAsId"))).thenReturn(as);
         ApplicationServiceImpl applicationService = new ApplicationServiceImpl(null, null, null, null, null, null,
@@ -550,7 +552,7 @@ public class ApplicationServiceImplTest {
         when(applicationSystemService.getApplicationSystem("myAs")).thenReturn(as);
 
         ValintaService valintaService = mock(ValintaService.class);
-        when(valintaService.fetchValintaData(Mockito.<Application>any())).thenReturn(application.getVastauksetMerged());
+        when(valintaService.fetchValintaData(Mockito.<Application>any(), Mockito.same(valintaTimeout))).thenReturn(application.getVastauksetMerged());
 
         ApplicationServiceImpl applicationService = new ApplicationServiceImpl(null, null, null, null, null, null,
                 null, applicationSystemService, null, null, null, null, null, valintaService, null, null, "true");
@@ -763,7 +765,7 @@ public class ApplicationServiceImplTest {
         when(phase.getAllChildren()).thenReturn(Collections.<Element>emptyList());
         when(applicationSystem.getForm()).thenReturn(form);
         final ValintaService valintaService = mock(ValintaService.class);
-        when(valintaService.fetchValintaData(application)).thenReturn(ImmutableMap.of("PK_A12", "10"));
+        when(valintaService.fetchValintaData(application, valintaTimeout)).thenReturn(ImmutableMap.of("PK_A12", "10"));
         final ApplicationServiceImpl applicationService = new ApplicationServiceImpl(null, null, null, null, null,
                 null, null, applicationSystemService, null, null, null, null, null, valintaService, null, null, null);
 

--- a/src/main/resources/oph-configuration/haku.properties.template
+++ b/src/main/resources/oph-configuration/haku.properties.template
@@ -111,6 +111,7 @@ user.home.conf=/data00/oph/haku/oph-configuration
 user.oid.prefix=1.2.246.562.24
 user.webservice.url.backend=https\://${host.virkailija}/authentication-service/services/userService
 valinta-default.timeout.millis=4000
+application.postprocessor.valinta.timeout.millis=120000
 valinta-tulos-service.timeout.millis=15000
 web.url.cas=https\://${host.cas}/cas
 


### PR DESCRIPTION
A few percent of these requests seem to fail, which makes jälkikäsittely fail
unneccessarily.
The UI cannot have a lot longer timeout than the current four seconds, because
it would suffocate the service.
