### PR TITLE
Mongokannan siirto DocumentDB:hen

### DIFF
--- a/hakemus-api/pom.xml
+++ b/hakemus-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>haku</artifactId>
         <groupId>fi.vm.sade.haku</groupId>
-        <version>15.5.1-SNAPSHOT</version>
+        <version>16.0-SNAPSHOT</version>
     </parent>
     <artifactId>hakemus-api</artifactId>
     <packaging>jar</packaging>

--- a/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/common/dao/AbstractDAOMongoImpl.java
+++ b/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/common/dao/AbstractDAOMongoImpl.java
@@ -91,7 +91,7 @@ public abstract class AbstractDAOMongoImpl<T> implements BaseDAO<T> {
             index.put(field, 1);
         }
         LOGGER.info(this.getClass().getSimpleName() +": Executin ensure index " + index+ " with options " + options);
-        getCollection().ensureIndex(index, options);
+        //getCollection().ensureIndex(index, options);
     }
 
     protected void checkIndexes(String message){

--- a/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/common/dao/AbstractDAOMongoImpl.java
+++ b/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/common/dao/AbstractDAOMongoImpl.java
@@ -64,24 +64,16 @@ public abstract class AbstractDAOMongoImpl<T> implements BaseDAO<T> {
     }
 
     protected void ensureIndex(String name, String... fields){
-        _ensureIndex(name, false, false, fields);
-    }
-
-    protected void ensureIndex(String name, Boolean isSparse, String... fields){
-        _ensureIndex(name, false, isSparse, fields);
+        _ensureIndex(name, false, fields);
     }
 
     protected void ensureUniqueIndex(String name, String... fields){
-        _ensureIndex(name, true, false, fields);
+        _ensureIndex(name, true, fields);
     }
-
-    protected void ensureSparseIndex(String name, String... fields){
-        _ensureIndex(name, false, true, fields);
-    }
-
-    private void _ensureIndex(String name, Boolean isUnique, Boolean isSparse, String... fields) {
+    
+    private void _ensureIndex(String name, Boolean isUnique, String... fields) {
         final DBObject options = new BasicDBObject(OPTION_NAME, name);
-        options.put(OPTION_SPARSE, isSparse.booleanValue());
+        options.put(OPTION_SPARSE, false);
         if (isUnique){
             options.put(OPTION_UNIQUE, isUnique);
         }
@@ -91,7 +83,7 @@ public abstract class AbstractDAOMongoImpl<T> implements BaseDAO<T> {
             index.put(field, 1);
         }
         LOGGER.info(this.getClass().getSimpleName() +": Executin ensure index " + index+ " with options " + options);
-        //getCollection().ensureIndex(index, options);
+        getCollection().createIndex(index, options);
     }
 
     protected void checkIndexes(String message){

--- a/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/hakemus/it/dao/impl/ApplicationDAOMongoImpl.java
+++ b/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/hakemus/it/dao/impl/ApplicationDAOMongoImpl.java
@@ -624,12 +624,12 @@ public class ApplicationDAOMongoImpl extends AbstractDAOMongoImpl<Application> i
         ensureIndex(INDEX_DATE_OF_BIRTH, FIELD_DATE_OF_BIRTH);
         ensureIndex(INDEX_PERSON_OID, FIELD_PERSON_OID);
         ensureIndex(INDEX_EMAIL, FIELD_EMAIL);
-        ensureSparseIndex(INDEX_SENDING_SCHOOL, FIELD_SENDING_SCHOOL, FIELD_SENDING_CLASS);
+        ensureIndex(INDEX_SENDING_SCHOOL, FIELD_SENDING_SCHOOL, FIELD_SENDING_CLASS);
         ensureIndex(INDEX_SEARCH_NAMES, FIELD_SEARCH_NAMES);
         ensureIndex(INDEX_FULL_NAME, FIELD_FULL_NAME, META_ALL_ORGANIZATIONS);
 
-        ensureSparseIndex(INDEX_ASID_SENDING_SCHOOL_AND_FULL_NAME, FIELD_APPLICATION_SYSTEM_ID, META_SENDING_SCHOOL_PARENTS, FIELD_FULL_NAME);
-        ensureSparseIndex(INDEX_ASID_AND_SENDING_SCHOOL, FIELD_APPLICATION_SYSTEM_ID, META_SENDING_SCHOOL_PARENTS);
+        ensureIndex(INDEX_ASID_SENDING_SCHOOL_AND_FULL_NAME, FIELD_APPLICATION_SYSTEM_ID, META_SENDING_SCHOOL_PARENTS, FIELD_FULL_NAME);
+        ensureIndex(INDEX_ASID_AND_SENDING_SCHOOL, FIELD_APPLICATION_SYSTEM_ID, META_SENDING_SCHOOL_PARENTS);
         ensureIndex(INDEX_STATE_ASID_AO_OID, FIELD_APPLICATION_STATE, FIELD_APPLICATION_SYSTEM_ID, META_FIELD_AO, FIELD_APPLICATION_OID);
         ensureIndex(INDEX_STATE_AO_OID, FIELD_APPLICATION_STATE, META_FIELD_AO, FIELD_APPLICATION_OID);
         ensureIndex(INDEX_ASID_AO_OID, FIELD_APPLICATION_SYSTEM_ID, META_FIELD_AO, FIELD_APPLICATION_OID);
@@ -640,17 +640,17 @@ public class ApplicationDAOMongoImpl extends AbstractDAOMongoImpl<Application> i
         ensureIndex(INDEX_ORG_OID, META_ALL_ORGANIZATIONS, FIELD_APPLICATION_OID);
         ensureIndex(INDEX_UPDATED, FIELD_UPDATED);
         ensureIndex(INDEX_UPDATED_RECEIVED, FIELD_RECEIVED, FIELD_UPDATED);
-        ensureSparseIndex(INDEX_PAYMENT_DUE_DATE, PAYMENT_DUE_DATE);
+        ensureIndex(INDEX_PAYMENT_DUE_DATE, PAYMENT_DUE_DATE);
 
         // System queries
-        ensureSparseIndex(INDEX_STUDENT_IDENTIFICATION_DONE, INDEX_STUDENT_IDENTIFICATION_DONE_FIELDS);
+        ensureIndex(INDEX_STUDENT_IDENTIFICATION_DONE, INDEX_STUDENT_IDENTIFICATION_DONE_FIELDS);
         ensureIndex(INDEX_POSTPROCESS, INDEX_POSTPROCESS_FIELDS);
         createIndexForSSNCheck();
         ensureIndex(INDEX_MODEL_VERSION, FIELD_MODEL_VERSION);
 
         // Preference Indexes
         for (int i = 1; i <= 8; i++) {
-            createPreferenceIndexes("preference" + i, i > 1,
+            createPreferenceIndexes("preference" + i,
                     format(FIELD_AO_T, i),
                     format(FIELD_AO_KOULUTUS_ID_T, i));
 
@@ -658,9 +658,9 @@ public class ApplicationDAOMongoImpl extends AbstractDAOMongoImpl<Application> i
         checkIndexes("after ensures");
     }
 
-    private void createPreferenceIndexes(String preference, boolean sparsePossible, String fieldAo, String fieldAoIdentifier) {
-        ensureIndex("index_" + preference + "_ao", sparsePossible, fieldAo);
-        ensureIndex("index_" + preference + "_ao_identifier", sparsePossible, fieldAoIdentifier);
+    private void createPreferenceIndexes(String preference, String fieldAo, String fieldAoIdentifier) {
+        ensureIndex("index_" + preference + "_ao", fieldAo);
+        ensureIndex("index_" + preference + "_ao_identifier", fieldAoIdentifier);
     }
 
     @Override

--- a/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/lomake/domain/ObjectIdDeserializer.java
+++ b/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/lomake/domain/ObjectIdDeserializer.java
@@ -24,7 +24,6 @@ import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
 
 import java.io.IOException;
-import java.util.Date;
 
 public class ObjectIdDeserializer extends JsonDeserializer<ObjectId> {
 
@@ -32,12 +31,14 @@ public class ObjectIdDeserializer extends JsonDeserializer<ObjectId> {
     public ObjectId deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
         final ObjectCodec codec = jsonParser.getCodec();
         final JsonNode treeNode = codec.readTree(jsonParser);
-        final long time = treeNode.get("time").asLong();
-        final int machine = treeNode.get("machine").asInt();
-        final int inc = treeNode.get("inc").asInt();
 
-        final ObjectId objectId = new ObjectId(new Date(time), machine, inc);
-        objectId.notNew();
-        return objectId;
+        if (treeNode.has("time") && treeNode.has("machine") && treeNode.has("inc")) {
+            final int time = treeNode.get("time").asInt();
+            final int machine = treeNode.get("machine").asInt();
+            final int inc = treeNode.get("inc").asInt();
+
+            return ObjectId.createFromLegacyFormat(time, machine, inc);
+        }
+        return null;
     }
 }

--- a/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/lomake/domain/elements/custom/HigherEducationAttachments.java
+++ b/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/lomake/domain/elements/custom/HigherEducationAttachments.java
@@ -17,11 +17,9 @@
 package fi.vm.sade.haku.oppija.lomake.domain.elements.custom;
 
 import com.google.common.collect.ImmutableMap;
-import com.mongodb.util.Hash;
 import fi.vm.sade.haku.oppija.lomake.domain.I18nText;
 import fi.vm.sade.haku.oppija.lomake.domain.elements.Titled;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class HigherEducationAttachments extends Titled {

--- a/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/repository/AuditLogRepository.java
+++ b/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/repository/AuditLogRepository.java
@@ -41,8 +41,8 @@ public class AuditLogRepository {
     private void initIndexes(){
         if (!ensureIndex)
             return;
-//        mongoOperations.getCollection(collectionName).ensureIndex(new BasicDBObject("_target",1), "index_target");
-//        mongoOperations.getCollection(collectionName).ensureIndex(new BasicDBObject("_targetType",1).append("_target",1), "index_targetType");
+        mongoOperations.getCollection(collectionName).createIndex(new BasicDBObject("_target",1), "index_target");
+        mongoOperations.getCollection(collectionName).createIndex(new BasicDBObject("_targetType",1).append("_target",1), "index_targetType");
     }
 
     public class TapahtumaToStringWrapper{

--- a/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/repository/AuditLogRepository.java
+++ b/hakemus-api/src/main/java/fi/vm/sade/haku/oppija/repository/AuditLogRepository.java
@@ -41,8 +41,8 @@ public class AuditLogRepository {
     private void initIndexes(){
         if (!ensureIndex)
             return;
-        mongoOperations.getCollection(collectionName).ensureIndex(new BasicDBObject("_target",1), "index_target");
-        mongoOperations.getCollection(collectionName).ensureIndex(new BasicDBObject("_targetType",1).append("_target",1), "index_targetType");
+//        mongoOperations.getCollection(collectionName).ensureIndex(new BasicDBObject("_target",1), "index_target");
+//        mongoOperations.getCollection(collectionName).ensureIndex(new BasicDBObject("_targetType",1).append("_target",1), "index_targetType");
     }
 
     public class TapahtumaToStringWrapper{

--- a/hakemus-api/src/main/java/fi/vm/sade/haku/virkailija/lomakkeenhallinta/dao/impl/DBConverter/ComplexObjectIdDeserializer.java
+++ b/hakemus-api/src/main/java/fi/vm/sade/haku/virkailija/lomakkeenhallinta/dao/impl/DBConverter/ComplexObjectIdDeserializer.java
@@ -22,11 +22,8 @@ import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.ObjectCodec;
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Date;
 
 public class ComplexObjectIdDeserializer extends JsonDeserializer<ObjectId> {
 
@@ -34,7 +31,7 @@ public class ComplexObjectIdDeserializer extends JsonDeserializer<ObjectId> {
     public ObjectId deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
         final ObjectCodec codec = jsonParser.getCodec();
         final JsonNode treeNode = codec.readTree(jsonParser);
-        if (treeNode.has("time")){
+        if (treeNode.has("time") && treeNode.has("machine") && treeNode.has("inc")) {
             return processSplinteredId(treeNode);
         }
         else if (treeNode.isTextual()) {
@@ -48,11 +45,10 @@ public class ComplexObjectIdDeserializer extends JsonDeserializer<ObjectId> {
     }
 
     private final ObjectId processSplinteredId(final JsonNode treeNode) {
-        final long time = treeNode.get("time").asLong();
+        final int time = treeNode.get("time").asInt();
         final int machine = treeNode.get("machine").asInt();
         final int inc = treeNode.get("inc").asInt();
-        final ObjectId objectId = new ObjectId(new Date(time), machine, inc);
-        objectId.notNew();
-        return objectId;
+
+        return ObjectId.createFromLegacyFormat(time, machine, inc);
     }
 }

--- a/haku-app/pom.xml
+++ b/haku-app/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>haku</artifactId>
         <groupId>fi.vm.sade.haku</groupId>
-        <version>15.5.1-SNAPSHOT</version>
+        <version>16.0-SNAPSHOT</version>
     </parent>
     <artifactId>haku-app</artifactId>
     <packaging>war</packaging>

--- a/haku-app/src/main/java/fi/vm/sade/haku/healthcheck/StatusRepositoryImpl.java
+++ b/haku-app/src/main/java/fi/vm/sade/haku/healthcheck/StatusRepositoryImpl.java
@@ -72,11 +72,7 @@ public class StatusRepositoryImpl implements StatusRepository {
         }
         newObject.put(FIELD_TIMESTAMP, new Date());
 
-        final WriteResult result = this.mongo.getCollection(STATUS_COLLECTION).update(query, newObject, true, false, WriteConcern.ACKNOWLEDGED);
-        final String error = result.getError();
-        if (isNotBlank(error)) {
-            log.error("Writing systemStatus failed: {}", error);
-        }
+        this.mongo.getCollection(STATUS_COLLECTION).update(query, newObject, true, false, WriteConcern.ACKNOWLEDGED);
     }
 
     @Override
@@ -88,11 +84,7 @@ public class StatusRepositoryImpl implements StatusRepository {
                 .append(FIELD_OPERATION, operation + LAST_SUCCESS)
                 .append(FIELD_TIMESTAMP, new Date())
                 .append(FIELD_STARTED, started);
-        final WriteResult result = mongo.getCollection(STATUS_COLLECTION).update(query, newRecord, true, false, WriteConcern.ACKNOWLEDGED);
-        final String error = result.getError();
-        if (isNotBlank(error)) {
-            log.error("Writing systemStatus failed: {}", error);
-        }
+        mongo.getCollection(STATUS_COLLECTION).update(query, newRecord, true, false, WriteConcern.ACKNOWLEDGED);
     }
 
     @Override
@@ -175,6 +167,6 @@ public class StatusRepositoryImpl implements StatusRepository {
     void initIndexes(){
         if (!ensureIndex)
             return;
-        this.mongo.getCollection(STATUS_COLLECTION).ensureIndex(new BasicDBObject(FIELD_HOST, 1).append(FIELD_OPERATION, 1),"index_update");
+        //this.mongo.getCollection(STATUS_COLLECTION).ensureIndex(new BasicDBObject(FIELD_HOST, 1).append(FIELD_OPERATION, 1),"index_update");
     }
 }

--- a/haku-app/src/main/java/fi/vm/sade/haku/healthcheck/StatusRepositoryImpl.java
+++ b/haku-app/src/main/java/fi/vm/sade/haku/healthcheck/StatusRepositoryImpl.java
@@ -167,6 +167,6 @@ public class StatusRepositoryImpl implements StatusRepository {
     void initIndexes(){
         if (!ensureIndex)
             return;
-        //this.mongo.getCollection(STATUS_COLLECTION).ensureIndex(new BasicDBObject(FIELD_HOST, 1).append(FIELD_OPERATION, 1),"index_update");
+        this.mongo.getCollection(STATUS_COLLECTION).createIndex(new BasicDBObject(FIELD_HOST, 1).append(FIELD_OPERATION, 1),"index_update");
     }
 }

--- a/haku-app/src/main/java/fi/vm/sade/haku/virkailija/lomakkeenhallinta/resources/ThemeQuestionResource.java
+++ b/haku-app/src/main/java/fi/vm/sade/haku/virkailija/lomakkeenhallinta/resources/ThemeQuestionResource.java
@@ -469,7 +469,9 @@ public class ThemeQuestionResource {
         queryParams.setApplicationSystemId(applicationSystemId);
 
         for (ThemeQuestion question : themeQuestionDAO.query(queryParams)) {
-            questionMap.put(question.getId(), themeQuestionConverter.convert(question, lang));
+            if (question.getId() != null) {
+                questionMap.put(question.getId(), themeQuestionConverter.convert(question, lang));
+            }
         }
 
         return ok(questionMap).build();

--- a/haku-auditlogger/pom.xml
+++ b/haku-auditlogger/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>haku</artifactId>
         <groupId>fi.vm.sade.haku</groupId>
-        <version>15.5.1-SNAPSHOT</version>
+        <version>16.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>haku-auditlogger</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>fi.vm.sade.haku</groupId>
     <artifactId>haku</artifactId>
-    <version>15.5.1-SNAPSHOT</version>
+    <version>16.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Haku :: Parent</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <spring-security.version>3.1.3.RELEASE</spring-security.version>
         <jersey.version>1.17.1</jersey.version>
         <servlet.version>3.0.1</servlet.version>
-        <mongo-driver.version>2.13.3</mongo-driver.version>
+        <mongo-driver.version>3.6.4</mongo-driver.version>
         <slf4j.version>1.7.6</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
         <cxf.version>2.7.3</cxf.version>


### PR DESCRIPTION
Tässä haarassa tehdyt muutokset mahdollistavat hakulomake-tietokannan siirtämisen perinteisestä mongosta Amazon DocumentDB:hen. Lähinnä mongodriver-riippuvuuden päivitys uudempaan ja siitä johtuvia koodimuutoksia. Myös sparse-indeksit on korvattu ei-sparseilla jotta ne toimisivat DocumentDB:ssä.